### PR TITLE
Add user name to registration and greet on dashboard

### DIFF
--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { createUserWithEmailAndPassword } from "firebase/auth";
+import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { db, auth } from "../../firebase";
 import { doc, setDoc } from "firebase/firestore";
 
 function Register({ setIsLoggedIn }) {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -22,7 +23,9 @@ function Register({ setIsLoggedIn }) {
         password
       );
       const user = userCredential.user;
+      await updateProfile(user, { displayName: name });
       await setDoc(doc(db, "users", user.uid), {
+        name,
         email,
         totalTime: 0,
         timeStudied: 0,
@@ -37,6 +40,13 @@ function Register({ setIsLoggedIn }) {
   return (
     <div className="form-container">
       <form onSubmit={handleSubmit}>
+        <label>Nama</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
         <label>Email</label>
         <input
           type="email"

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -66,7 +66,7 @@ export default function Page() {
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (user) => {
       setSudahLogin(!!user);
-      setIdPengguna(user ? user.uid : null);
+      setIdPengguna(user ? user.displayName : null);
     });
     return () => unsub();
   }, []);


### PR DESCRIPTION
## Summary
- capture user display name during registration and store it in Firebase
- greet logged in users by name on the dashboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint setup)

------
https://chatgpt.com/codex/tasks/task_e_68a72ec64d848322b71ed77f41f397ef