### PR TITLE
Fix Pomodoro timer to use saved settings

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -220,30 +220,6 @@ export default function Page() {
    * =================================================================== */
   const [bukaPengaturan, setBukaPengaturan] = useState(false);
 
-  const simpanPengaturan = (baru) => {
-    const norm = {
-      workLen: Math.max(1, Number(baru.workLen ?? pengaturanTimer.workLen)),
-      shortBreakLen: Math.max(
-        1,
-        Number(baru.shortBreakLen ?? pengaturanTimer.shortBreakLen)
-      ),
-      longBreakLen: Math.max(
-        1,
-        Number(baru.longBreakLen ?? pengaturanTimer.longBreakLen)
-      ),
-      longBrInterval: Math.max(
-        2,
-        Number(baru.longBrInterval ?? pengaturanTimer.longBrInterval)
-      ),
-      volume: Math.min(
-        100,
-        Math.max(0, Number(baru.volume ?? pengaturanTimer.volume))
-      ),
-    };
-    setPengaturanTimer(norm);
-    setBukaPengaturan(false);
-  };
-
   /* ===================================================================
    *  6) Info login untuk anak
    * =================================================================== */
@@ -383,10 +359,27 @@ export default function Page() {
         lebar="md"
       >
         <SettingsForm
-          pengaturan={pengaturanTimer}
-          setPengaturan={setPengaturanTimer}
-          onSimpan={simpanPengaturan}
-          onSelesai={() => setBukaPengaturan(false)}
+          workLen={pengaturanTimer.workLen}
+          setWorkLen={(v) =>
+            setPengaturanTimer((prev) => ({ ...prev, workLen: v }))
+          }
+          shortBreakLen={pengaturanTimer.shortBreakLen}
+          setShortBreakLen={(v) =>
+            setPengaturanTimer((prev) => ({ ...prev, shortBreakLen: v }))
+          }
+          longBreakLen={pengaturanTimer.longBreakLen}
+          setLongBreakLen={(v) =>
+            setPengaturanTimer((prev) => ({ ...prev, longBreakLen: v }))
+          }
+          longBrInterval={pengaturanTimer.longBrInterval}
+          setLongBrInterval={(v) =>
+            setPengaturanTimer((prev) => ({ ...prev, longBrInterval: v }))
+          }
+          volume={pengaturanTimer.volume}
+          setVolume={(v) =>
+            setPengaturanTimer((prev) => ({ ...prev, volume: v }))
+          }
+          onTutup={() => setBukaPengaturan(false)}
         />
       </Modal>
 


### PR DESCRIPTION
## Summary
- pass individual Pomodoro settings and setters to `SettingsForm` so updates persist to the timer
- remove unused helper for updating settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(could not run – requires interactive setup)*
- `npm run build` *(fails: FirebaseError: auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68a7355ffca08322b9ba879b404884df