### PR TITLE
Align auth form styling with SettingsForm

### DIFF
--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { signInWithEmailAndPassword } from "firebase/auth";
-import { db, auth } from "../../firebase";
+import { auth } from "../../firebase";
+import "../../styles/SettingsForm.css";
 
 function Login({ setIsLoggedIn }) {
   const [email, setEmail] = useState("");
@@ -18,10 +19,10 @@ function Login({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="pixel-card w-full max-w-md mx-auto p-6">
+    <div className="Sf">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <label htmlFor="login-email" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="login-email" className="Sf__label">
             Email
           </label>
           <input
@@ -29,12 +30,12 @@ function Login({ setIsLoggedIn }) {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label htmlFor="login-password" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="login-password" className="Sf__label">
             Password
           </label>
           <input
@@ -42,22 +43,18 @@ function Login({ setIsLoggedIn }) {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
         <button
           type="submit"
-          className="pixel-btn pixel-btn--primary w-full mt-2"
+          className="Sf__btn Sf__btn--primary w-full mt-2"
         >
           Login
         </button>
       </form>
-      {errorMessage && (
-        <div className="text-red-400 text-xs mt-3 text-center">
-          {errorMessage}
-        </div>
-      )}
+      {errorMessage && <div className="Sf__error">{errorMessage}</div>}
     </div>
   );
 }

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { db, auth } from "../../firebase";
 import { doc, setDoc } from "firebase/firestore";
+import "../../styles/SettingsForm.css";
 
 function Register({ setIsLoggedIn }) {
   const [name, setName] = useState("");
@@ -38,10 +39,10 @@ function Register({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="pixel-card w-full max-w-md mx-auto p-6">
+    <div className="Sf">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <label htmlFor="register-name" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="register-name" className="Sf__label">
             Nama
           </label>
           <input
@@ -49,12 +50,12 @@ function Register({ setIsLoggedIn }) {
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label htmlFor="register-email" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="register-email" className="Sf__label">
             Email
           </label>
           <input
@@ -62,12 +63,12 @@ function Register({ setIsLoggedIn }) {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label htmlFor="register-password" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="register-password" className="Sf__label">
             Password
           </label>
           <input
@@ -75,12 +76,12 @@ function Register({ setIsLoggedIn }) {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label htmlFor="register-confirm" className="text-sm">
+        <div className="Sf__group">
+          <label htmlFor="register-confirm" className="Sf__label">
             Confirm Password
           </label>
           <input
@@ -88,22 +89,18 @@ function Register({ setIsLoggedIn }) {
             type="password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
+            className="Sf__number"
             required
           />
         </div>
         <button
           type="submit"
-          className="pixel-btn pixel-btn--primary w-full mt-2"
+          className="Sf__btn Sf__btn--primary w-full mt-2"
         >
           Register
         </button>
       </form>
-      {errorMessage && (
-        <div className="text-red-400 text-xs mt-3 text-center">
-          {errorMessage}
-        </div>
-      )}
+      {errorMessage && <div className="Sf__error">{errorMessage}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle login form with SettingsForm CSS and pixel borders
- restyle register form using same SettingsForm input and button styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a7388595fc83229ed028a368188c25