### PR TITLE
Fix duplicate login modal and tidy form styling

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -323,16 +323,6 @@ export default function Page() {
         </div>
       </div>
 
-      {/* Pop-up login/register */}
-      {loginOpen && (
-        <div className="login-popup-overlay">
-          <div className="login-popup">
-            <LoginRegisterForm setIsLoggedIn={setIsLoggedIn} />
-            <button onClick={() => setLoginOpen(false)}>Tutup</button>
-          </div>
-        </div>
-      )}
-
       {/* Timer */}
       <Timer
         workLen={pengaturanTimer.workLen}
@@ -408,7 +398,7 @@ export default function Page() {
         judul="Akun"
         deskripsi="Kelola login / register akun Anda."
       >
-        <LoginRegisterForm />
+        <LoginRegisterForm setIsLoggedIn={setIsLoggedIn} />
       </Modal>
     </main>
   );

--- a/src/app/styles/SettingsForm.css
+++ b/src/app/styles/SettingsForm.css
@@ -1,15 +1,12 @@
 /* Wadah utama SettingsForm */
 .Sf {
-  width: min(80vw, 500px); /* Lebar lebih kecil untuk kesan compact */
+  width: 100%;
   font-family: var(--font-pixel);
   color: var(--foreground);
-  margin: 20px auto;
-  padding: 16px; /* Padding lebih kecil untuk compact */
+  margin: 0;
+  padding: 16px;
   border-radius: 8px;
-  background: transparent; /* Latar belakang transparan */
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.2); /* Efek shadow halus */
-  z-index: 2000; /* Pastikan form tetap di atas modal */
-  position: relative; /* Posisi relative agar tidak tertimpa oleh modal */
+  background: transparent;
 }
 
 /* Judul section SettingsForm */


### PR DESCRIPTION
## Summary
- Remove redundant login/register overlay to avoid double rendering
- Use existing Modal for account forms and ensure login status updates
- Simplify form container styling for consistent layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint configuration prompt prevents non-interactive run)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c1ed218832291e52fa095584714