### PR TITLE
Fix wallpaper button width and volume bar length

### DIFF
--- a/src/app/components/Music/MusicPlayer.js
+++ b/src/app/components/Music/MusicPlayer.js
@@ -403,7 +403,7 @@ export default function MusicPlayer({ namaWallpaper = "", onGantiWallpaper }) {
             </label>
             <input
               id="volume-musik"
-              className="Mp__slider"
+              className="Mp__slider Mp__slider--volume"
               type="range"
               min="0"
               max="100"

--- a/src/app/styles/MusicPlayer.css
+++ b/src/app/styles/MusicPlayer.css
@@ -80,6 +80,11 @@
   cursor: pointer;
 }
 
+/* Slider volume perlu fleksibel agar memanjang */
+.Mp__slider--volume {
+  flex: 1;
+}
+
 .Mp__slider::-webkit-slider-thumb {
   appearance: none;
   width: 10px; /* lebih kecil */
@@ -143,7 +148,6 @@
 
 .Mp__opsi-bar {
   display: flex;
-  flex: 1;
   justify-content: flex-end;
   align-items: center;
   gap: 6px;
@@ -166,6 +170,8 @@
   padding: 3px 5px;
   cursor: pointer;
   white-space: nowrap;
+  width: 10ch; /* samakan panjang dengan teks 'background' */
+  text-align: center;
 }
 
 .Mp__label {


### PR DESCRIPTION
## Summary
- keep wallpaper change button a consistent width
- enlarge volume slider and stop options bar from squeezing it

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompt for ESLint config)
- `npm run build` (fails: Firebase auth/invalid-api-key)


------
https://chatgpt.com/codex/tasks/task_e_68a73e1760108322bcdd22ea52d25865