### PR TITLE
Adjust wallpaper button width and volume spacing

### DIFF
--- a/src/app/styles/MusicPlayer.css
+++ b/src/app/styles/MusicPlayer.css
@@ -156,7 +156,7 @@
 .Mp__opsi-left {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   flex: 1;
 }
 
@@ -170,7 +170,7 @@
   padding: 3px 5px;
   cursor: pointer;
   white-space: nowrap;
-  width: 10ch; /* samakan panjang dengan teks 'background' */
+  width: 12ch; /* lebar tambahan agar teks 'background' muat */
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- expand wallpaper button so "background" text fits
- shift volume controls right for balanced layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7407855cc832283275bc9b0cbb0bf