### PR TITLE
Use modal for stats and hide login/register after login

### DIFF
--- a/src/app/components/Timer/UserStatistics.js
+++ b/src/app/components/Timer/UserStatistics.js
@@ -12,7 +12,6 @@
  *   3) localStorage (jika ada data)
  */
 
-import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import "../../styles/UserStatistics.css";
 
@@ -221,88 +220,70 @@ export default function UserStatistics({
 
   // ---------------- UI ----------------
   return (
-    <div className={`Stat__bungkus ${className || ""}`}>
-      <section className="Stat">
-        {/* Header */}
-        <header className="Stat__header">
-          <div className="Stat__judul">
-            <Image
-              src="/images/stats.png"
-              alt="ikon statistik"
-              width={20}
-              height={20}
-              className="Stat__ikon"
-              priority
-            />
-            <h3>statistik</h3>
-          </div>
+    <section className={`Stat ${className || ""}`}>
+      {/* Tabs */}
+      <div className="Stat__tab">
+        <button
+          className={`Stat__tabbtn ${
+            modeTampil === "total" ? "is-aktif" : ""
+          }`}
+          onClick={() => setModeTampil("total")}
+          type="button"
+        >
+          total
+        </button>
+        <button
+          className={`Stat__tabbtn ${
+            modeTampil === "harian" ? "is-aktif" : ""
+          }`}
+          onClick={() => setModeTampil("harian")}
+          type="button"
+          title="Statistik untuk hari kalender ini"
+        >
+          hari ini
+        </button>
+      </div>
 
-          <div className="Stat__tab">
-            <button
-              className={`Stat__tabbtn ${
-                modeTampil === "total" ? "is-aktif" : ""
-              }`}
-              onClick={() => setModeTampil("total")}
-              type="button"
-            >
-              total
-            </button>
-            <button
-              className={`Stat__tabbtn ${
-                modeTampil === "harian" ? "is-aktif" : ""
-              }`}
-              onClick={() => setModeTampil("harian")}
-              type="button"
-              title="Statistik untuk hari kalender ini"
-            >
-              hari ini
-            </button>
-          </div>
-        </header>
+      {/* Status */}
+      <div className="Stat__status">
+        <span className={`Stat__dot ${loggedIn || uidAktif ? "on" : "off"}`} />
+        <span className="Stat__status-teks">
+          {sedangMuat
+            ? "memuat…"
+            : loggedIn || uidAktif
+            ? "tersambung data"
+            : "mode lokal"}
+          <span className="Stat__sub"> • {dataTampil.judulKecil}</span>
+        </span>
+      </div>
 
-        {/* Status */}
-        <div className="Stat__status">
-          <span
-            className={`Stat__dot ${loggedIn || uidAktif ? "on" : "off"}`}
-          />
-          <span className="Stat__status-teks">
-            {sedangMuat
-              ? "memuat…"
-              : loggedIn || uidAktif
-              ? "tersambung data"
-              : "mode lokal"}
-            <span className="Stat__sub"> • {dataTampil.judulKecil}</span>
-          </span>
+      {/* Grid angka */}
+      <div className="Stat__grid" role="list">
+        <article className="Stat__kartu" role="listitem">
+          <h4 className="Stat__kartu-judul">fokus</h4>
+          <p className="Stat__angka">{Number(dataTampil.fokus || 0)}</p>
+          <span className="Stat__unit">menit</span>
+        </article>
+
+        <article className="Stat__kartu" role="listitem">
+          <h4 className="Stat__kartu-judul">istirahat</h4>
+          <p className="Stat__angka">{Number(dataTampil.istirahat || 0)}</p>
+          <span className="Stat__unit">menit</span>
+        </article>
+
+        <article className="Stat__kartu Stat__kartu-total" role="listitem">
+          <h4 className="Stat__kartu-judul">total</h4>
+          <p className="Stat__angka">{Number(dataTampil.total || 0)}</p>
+          <span className="Stat__unit">menit</span>
+        </article>
+      </div>
+
+      {/* Pesan error (jika ada) */}
+      {pesanError && (
+        <div className="Stat__alert error" role="alert">
+          {pesanError}
         </div>
-
-        {/* Grid angka */}
-        <div className="Stat__grid" role="list">
-          <article className="Stat__kartu" role="listitem">
-            <h4 className="Stat__kartu-judul">fokus</h4>
-            <p className="Stat__angka">{Number(dataTampil.fokus || 0)}</p>
-            <span className="Stat__unit">menit</span>
-          </article>
-
-          <article className="Stat__kartu" role="listitem">
-            <h4 className="Stat__kartu-judul">istirahat</h4>
-            <p className="Stat__angka">{Number(dataTampil.istirahat || 0)}</p>
-            <span className="Stat__unit">menit</span>
-          </article>
-
-          <article className="Stat__kartu Stat__kartu-total" role="listitem">
-            <h4 className="Stat__kartu-judul">total</h4>
-            <p className="Stat__angka">{Number(dataTampil.total || 0)}</p>
-            <span className="Stat__unit">menit</span>
-          </article>
-        </div>
-
-        {/* Pesan error (jika ada) */}
-        {pesanError && (
-          <div className="Stat__alert error" role="alert">
-            {pesanError}
-          </div>
-        )}
-      </section>
-    </div>
+      )}
+    </section>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -85,6 +85,12 @@ export default function Page() {
     return () => unsub();
   }, []);
 
+  useEffect(() => {
+    if (isLoggedIn || sudahLogin) {
+      setLoginOpen(false);
+    }
+  }, [isLoggedIn, sudahLogin]);
+
   /* ===================================================================
    *  2) Pengaturan & Periode Aktif
    * =================================================================== */
@@ -298,16 +304,18 @@ export default function Page() {
           />
         </button>
         {/* akun */}
-        <button className="account-button" onClick={() => setLoginOpen(true)}>
-          <Image
-            src="/images/info.png"
-            alt="ikon akun"
-            width={20}
-            height={20}
-            className="account-icon"
-            priority
-          />
-        </button>
+        {!sudahLogin && !isLoggedIn && (
+          <button className="account-button" onClick={() => setLoginOpen(true)}>
+            <Image
+              src="/images/info.png"
+              alt="ikon akun"
+              width={20}
+              height={20}
+              className="account-icon"
+              priority
+            />
+          </button>
+        )}
         <div className="Db__status">
           <span
             className={`Db__dot ${sudahLogin ? "is-on" : "is-off"}`}
@@ -336,21 +344,20 @@ export default function Page() {
       />
 
       {/* Statistik */}
-      {bukaStatistik && (
-        <>
-          <div
-            className="Stat__overlay"
-            onClick={() => setBukaStatistik(false)}
-          />
-          <UserStatistics
-            loggedIn={infoLogin.loggedIn}
-            userId={infoLogin.userId}
-            totalTime={statRingkas.totalTime}
-            timeStudied={statRingkas.timeStudied}
-            timeOnBreak={statRingkas.timeOnBreak}
-          />
-        </>
-      )}
+      <Modal
+        buka={bukaStatistik}
+        tutup={() => setBukaStatistik(false)}
+        judul="Statistik"
+        lebar="md"
+      >
+        <UserStatistics
+          loggedIn={infoLogin.loggedIn}
+          userId={infoLogin.userId}
+          totalTime={statRingkas.totalTime}
+          timeStudied={statRingkas.timeStudied}
+          timeOnBreak={statRingkas.timeOnBreak}
+        />
+      </Modal>
 
       {/* Music Player */}
       <div className="area-music-bawah">

--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -7,22 +7,6 @@
   font-display: swap;
 }
 
-/* Bungkus Statistik ------------------------------------------------------ */
-.Stat__bungkus {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%); /* Selalu di tengah */
-  z-index: 60;
-  width: min(90vw, 500px); /* Menyesuaikan layar */
-  max-height: 85vh; /* Biar tidak terpotong di layar kecil */
-  pointer-events: auto;
-  animation: fadeIn 200ms ease-out;
-  transition: transform 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
 /* Kartu Statistik -------------------------------------------------------- */
 .Stat {
   background: var(--glass);
@@ -35,50 +19,15 @@
   font-family: "Monocraft", monospace;
   pointer-events: auto;
   overflow-y: auto;
-  max-height: 100%; /* Biar ikut ukuran bungkus */
+  max-height: 100%;
+  width: 100%;
 }
-
-/* Overlay ---------------------------------------------------------------- */
-.Stat__overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(3px);
-  -webkit-backdrop-filter: blur(3px);
-  z-index: 59;
-  animation: fadeIn 200ms ease-out;
-}
-
-/* Header ----------------------------------------------------------------- */
-.Stat__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 8px;
-  cursor: move;
-}
-
-.Stat__judul {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.Stat__judul h3 {
-  margin: 0;
-  font-size: 12px;
-  letter-spacing: 1px;
-}
-
-.Stat__ikon {
-  image-rendering: pixelated;
-}
-
 /* Tabs ------------------------------------------------------------------- */
 .Stat__tab {
   display: flex;
   gap: 6px;
+  justify-content: center;
+  margin-bottom: 8px;
 }
 
 .Stat__tabbtn {


### PR DESCRIPTION
## Summary
- hide login/register trigger once user is authenticated
- show user statistics in a modal with close button
- align statistics styling with other modals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f28a2e08322ae210cc3742e6ecf