### PR TITLE
Align User Statistics styling with Settings

### DIFF
--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -9,13 +9,13 @@
 
 /* Kartu Statistik -------------------------------------------------------- */
 .Stat {
-  background: var(--glass);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  border: 2px solid #ffffff;
-  box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
-  border-radius: 6px;
-  padding: 12px;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+  box-shadow: none;
+  border-radius: 8px;
+  padding: 16px;
   font-family: "Monocraft", monospace;
   pointer-events: auto;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Make user statistics card borderless with transparent background to match Settings style

## Testing
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a74336cbdc8322872ef236c62f6924