### PR TITLE
Add MIT license and tweak statistics/settings UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Pomo-Pixel contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lofi",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/app/components/Timer/SettingsForm.js
+++ b/src/app/components/Timer/SettingsForm.js
@@ -25,9 +25,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
 import "../../styles/SettingsForm.css";
-import UserStatistics from "./UserStatistics";
 import { db, auth } from "../../firebase";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
@@ -51,7 +49,6 @@ export default function SettingsForm({
   statsPosition,
   setStatsPosition,
   userId, // opsional
-  onTutup, // opsional: untuk menutup modal dari parent
   className = "",
 }) {
   // ---------- state UI & pesan ----------
@@ -130,12 +127,6 @@ export default function SettingsForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uidAktif]);
 
-  // Initialize `bacaTotal` for UserStatistics (Add this state)
-  const [bacaTotal, setBacaTotal] = useState({
-    totalMenit: 0,
-    menitFokus: 0,
-    menitIstirahat: 0,
-  });
 
   // ---------- validasi sederhana ----------
   const validasi = () => {
@@ -341,11 +332,6 @@ export default function SettingsForm({
           <button className="Sf__btn" type="button" onClick={resetKeBawaan}>
             Reset
           </button>
-          {onTutup && (
-            <button className="Sf__btn" type="button" onClick={onTutup}>
-              Tutup
-            </button>
-          )}
           <button
             className="Sf__btn Sf__btn--primary"
             type="submit"

--- a/src/app/styles/SettingsForm.css
+++ b/src/app/styles/SettingsForm.css
@@ -74,8 +74,8 @@
 /* Tombol dan aksi */
 .Sf__actions {
   display: flex;
-  justify-content: space-between;
-  gap: 8px; /* Gap lebih kecil */
+  justify-content: center;
+  gap: 12px; /* Jarak tombol sedikit lebih lebar */
   margin-top: 16px; /* Margin lebih kecil */
 }
 
@@ -83,7 +83,7 @@
 .Sf__btn {
   font-family: var(--font-pixel);
   background: var(--aksen-amber);
-  padding: 8px 14px; /* Padding lebih kecil */
+  padding: 10px 20px; /* Tombol sedikit lebih lebar */
   border: 2px solid #ffffff;
   border-radius: 8px;
   cursor: pointer;

--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -9,11 +9,11 @@
 
 /* Kartu Statistik -------------------------------------------------------- */
 .Stat {
-  background: transparent;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  background: var(--glass, rgba(255, 255, 255, 0.12));
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   border: none;
-  box-shadow: none;
+  box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
   border-radius: 8px;
   padding: 16px;
   font-family: "Monocraft", monospace;
@@ -92,7 +92,7 @@
 
 .Stat__kartu {
   background: rgba(17, 24, 39, 0.65);
-  border: 2px solid #000;
+  border: none;
   box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
   padding: 10px 8px;
   text-align: center;
@@ -129,7 +129,7 @@
   margin-top: 10px;
   background: #b91c1c;
   color: #fff;
-  border: 2px solid #000;
+  border: none;
   box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
   padding: 8px 10px;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- add MIT license and update package metadata
- restyle user statistics panel to match app and hide borders
- remove settings close button and widen primary buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(incomplete: Next.js prompted for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a745cac2888322a5bf1d3ad676cab3