### PR TITLE
Sharpen statistics UI

### DIFF
--- a/src/app/components/Timer/UserStatistics.js
+++ b/src/app/components/Timer/UserStatistics.js
@@ -221,6 +221,7 @@ export default function UserStatistics({
   // ---------------- UI ----------------
   return (
     <section className={`Stat ${className || ""}`}>
+      <div className="Stat__section-title">Statistik</div>
       {/* Tabs */}
       <div className="Stat__tab">
         <button

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -347,7 +347,6 @@ export default function Page() {
       <Modal
         buka={bukaStatistik}
         tutup={() => setBukaStatistik(false)}
-        judul="Statistik"
         lebar="md"
       >
         <UserStatistics

--- a/src/app/styles/SettingsForm.css
+++ b/src/app/styles/SettingsForm.css
@@ -5,7 +5,7 @@
   color: var(--foreground);
   margin: 0;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: 0;
   background: transparent;
 }
 
@@ -45,7 +45,7 @@
   width: 100%;
   height: 32px; /* Ukuran lebih kecil */
   padding: 6px; /* Padding lebih kecil */
-  border-radius: 8px;
+  border-radius: 0;
   background: transparent; /* Menghapus latar belakang */
   border: 2px solid #ffffff;
   color: var(--foreground);
@@ -66,7 +66,7 @@
 
 .Sf__range::-webkit-slider-thumb {
   background-color: var(--aksen-amber);
-  border-radius: 50%;
+  border-radius: 0;
   width: 14px; /* Ukuran thumb lebih kecil */
   height: 14px;
 }
@@ -85,7 +85,7 @@
   background: var(--aksen-amber);
   padding: 10px 20px; /* Tombol sedikit lebih lebar */
   border: 2px solid #ffffff;
-  border-radius: 8px;
+  border-radius: 0;
   cursor: pointer;
   transition: transform 0.2s ease, background 0.3s ease;
   font-size: 14px;
@@ -111,7 +111,7 @@
   color: #ff4d4d;
   background: rgba(255, 0, 0, 0.2);
   padding: 6px;
-  border-radius: 6px;
+  border-radius: 0;
   text-align: center;
   margin-top: 8px; /* Margin lebih kecil */
 }
@@ -121,7 +121,7 @@
   color: #3e8e41;
   background: rgba(0, 255, 0, 0.2);
   padding: 6px;
-  border-radius: 6px;
+  border-radius: 0;
   text-align: center;
   margin-top: 8px; /* Margin lebih kecil */
 }

--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -12,13 +12,20 @@
   background: transparent;
   border: none;
   box-shadow: none;
-  border-radius: 8px;
+  border-radius: 0;
   padding: 16px;
   font-family: "Monocraft", monospace;
   pointer-events: auto;
   overflow-y: auto;
   max-height: 100%;
   width: 100%;
+}
+
+.Stat__section-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 16px;
+  text-align: center;
 }
 /* Tabs ------------------------------------------------------------------- */
 .Stat__tab {
@@ -90,10 +97,11 @@
 
 .Stat__kartu {
   background: rgba(17, 24, 39, 0.65);
-  border: none;
+  border: 2px solid #ffffff;
   box-shadow: none;
   padding: 10px 8px;
   text-align: center;
+  border-radius: 0;
 }
 
 .Stat__kartu-judul {


### PR DESCRIPTION
## Summary
- move "Statistik" heading into user statistics panel
- square off statistic cards and settings form controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a74fddd1208322a1668cc8630a2056