### PR TITLE
Add pixel-style borders to auth and settings inputs

### DIFF
--- a/src/app/styles/SettingsForm.css
+++ b/src/app/styles/SettingsForm.css
@@ -48,8 +48,8 @@
   padding: 6px; /* Padding lebih kecil */
   border-radius: 0;
   background: transparent; /* Menghapus latar belakang */
-  border: none;
-  box-shadow: none;
+  border: 2px solid #000;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
   color: var(--foreground);
   font-size: 14px;
   font-family: var(--font-pixel);


### PR DESCRIPTION
## Summary
- add pixelated border and box-shadow to settings and auth input fields for consistent theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration input)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cc2fc0083229ee3bcd432b8e80b