### PR TITLE
feat: handle github oauth callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ NEXT_PUBLIC_GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 NEXT_PUBLIC_GITHUB_REDIRECT_URI=http://localhost:3000/
 
+# URL di atas adalah halaman yang menerima `code` dari GitHub.  
+# Token akan ditukar melalui route server: `/api/github/callback`.
+
 ```
 
 ### 3️⃣ Jalankan Server Pengembangan

--- a/src/app/api/github/callback/route.js
+++ b/src/app/api/github/callback/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 });
+  }
+
+  const response = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+      redirect_uri: process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI,
+    }),
+  });
+
+  const data = await response.json();
+  if (data.error) {
+    return NextResponse.json(data, { status: 400 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/github.js
+++ b/src/app/github.js
@@ -1,28 +1,23 @@
 const CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
-const CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
-const REDIRECT_URI = process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI || (typeof window !== 'undefined' ? window.location.origin : '');
+const REDIRECT_URI =
+  process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
+
+if (!CLIENT_ID) {
+  throw new Error('NEXT_PUBLIC_GITHUB_CLIENT_ID tidak ditemukan');
+}
 
 export function redirectToGitHub() {
-  const url = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=repo`;
+  const url = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(
+    REDIRECT_URI
+  )}&scope=repo`;
   if (typeof window !== 'undefined') {
     window.location.href = url;
   }
 }
 
 export async function exchangeCodeForToken(code) {
-  const res = await fetch('https://github.com/login/oauth/access_token', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      code,
-      redirect_uri: REDIRECT_URI,
-    }),
-  });
+  const res = await fetch(`/api/github/callback?code=${encodeURIComponent(code)}`);
   const data = await res.json();
   return data.access_token;
 }


### PR DESCRIPTION
## Summary
- add Next.js API route to exchange GitHub OAuth code for a token
- verify GitHub client ID env and delegate token exchange to API route
- document GitHub OAuth variables and callback route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build` *(fails: Firebase: Error (auth/invalid-api-key))*

------
https://chatgpt.com/codex/tasks/task_e_68a85b7378a88322b55b1fb3a3f6f27b