### PR TITLE
Refine GitHub login UI and timer messages

### DIFF
--- a/src/app/components/Timer/LoginRegisterForm.js
+++ b/src/app/components/Timer/LoginRegisterForm.js
@@ -29,7 +29,7 @@ function LoginRegisterForm({ setIsLoggedIn }) {
       <button
         type="button"
         onClick={() => redirectToGitHub()}
-        className="Sf__btn Sf__btn--primary w-full"
+        className="Sf__btn Sf__btn--primary w-full mt-2"
       >
         Login with GitHub
       </button>

--- a/src/app/components/Timer/Timer.js
+++ b/src/app/components/Timer/Timer.js
@@ -167,7 +167,7 @@ export default function Timer({
       setSisaDetik(sisa);
     }
     setBerjalan(false);
-    setPesanInfo("dijeda");
+    setPesanInfo("");
     try {
       onJeda?.();
     } catch {}

--- a/src/app/components/Timer/UserStatistics.js
+++ b/src/app/components/Timer/UserStatistics.js
@@ -285,7 +285,7 @@ export default function UserStatistics({
         <div className="Stat__github">
           <h4 className="Stat__kartu-judul">GitHub Activity</h4>
           <ul className="Stat__github-list">
-            {githubEvents.map((ev) => (
+            {githubEvents.slice(0, 5).map((ev) => (
               <li key={ev.id} className="Stat__github-item">
                 <span className="repo">{ev.repo}</span>
                 <span className="commit">{ev.commit?.slice(0, 7)}</span>


### PR DESCRIPTION
## Summary
- Align GitHub login button styling with other login options
- Show only the five most recent GitHub activity entries
- Remove pause status text under timer controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a8672d5a7c8322b3befa47566f79c4