### PR TITLE
Restore original login and register design

### DIFF
--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -1,42 +1,27 @@
 import { useState } from "react";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../firebase";
-import "../../styles/SettingsForm.css";
 
-/**
- * Form login sederhana untuk autentikasi Firebase.
- * Mengirim status login ke parent melalui setIsLoggedIn.
- */
 function Login({ setIsLoggedIn }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  // Tangani submit form login
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    // pastikan callback tersedia
-    if (typeof setIsLoggedIn !== "function") {
-      setErrorMessage("Fungsi setIsLoggedIn belum tersedia.");
-      return;
-    }
-
     try {
       await signInWithEmailAndPassword(auth, email, password);
-      setIsLoggedIn(true); // user berhasil login
+      setIsLoggedIn(true); // User berhasil login
     } catch (error) {
-      console.error("Gagal login:", error);
       setErrorMessage("Gagal login: " + error.message);
     }
   };
 
   return (
-    <div className="Sf">
-      <h2 className="Sf__section-title">Login</h2>
+    <div className="pixel-card w-full max-w-md mx-auto p-6">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div className="Sf__group">
-          <label htmlFor="login-email" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="login-email" className="text-sm">
             Email
           </label>
           <input
@@ -44,12 +29,12 @@ function Login({ setIsLoggedIn }) {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
-        <div className="Sf__group">
-          <label htmlFor="login-password" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="login-password" className="text-sm">
             Password
           </label>
           <input
@@ -57,18 +42,22 @@ function Login({ setIsLoggedIn }) {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
         <button
           type="submit"
-          className="Sf__btn Sf__btn--primary w-full mt-2"
+          className="pixel-btn pixel-btn--primary w-full mt-2"
         >
           Login
         </button>
       </form>
-      {errorMessage && <div className="Sf__error">{errorMessage}</div>}
+      {errorMessage && (
+        <div className="text-red-400 text-xs mt-3 text-center">
+          {errorMessage}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/components/Timer/LoginRegisterForm.js
+++ b/src/app/components/Timer/LoginRegisterForm.js
@@ -3,24 +3,15 @@ import Login from "./Login";
 import Register from "./Register";
 import { redirectToGitHub } from "../../github";
 
-/**
- * Pembungkus form login dan registrasi.
- * Menampilkan salah satu form dan menyediakan tombol untuk berpindah.
- */
 function LoginRegisterForm({ setIsLoggedIn }) {
   const [currentForm, setCurrentForm] = useState("login");
 
-  // Ganti form yang sedang ditampilkan dengan validasi nama
   const toggleForm = (formName) => {
-    if (formName !== "login" && formName !== "register") {
-      console.error(`Form tidak dikenal: ${formName}`);
-      return;
-    }
     setCurrentForm(formName);
   };
 
   return (
-    <div className="flex flex-col items-center gap-4 w-full max-w-xs">
+    <div className="flex flex-col items-center gap-4">
       {currentForm === "login" ? (
         <Login setIsLoggedIn={setIsLoggedIn} />
       ) : (
@@ -29,30 +20,21 @@ function LoginRegisterForm({ setIsLoggedIn }) {
       <button
         type="button"
         onClick={() => redirectToGitHub()}
-        className="Sf__btn Sf__btn--primary w-full mt-2"
+        className="pixel-btn pixel-btn--primary w-full"
       >
         Login with GitHub
       </button>
-      {currentForm === "login" ? (
-        <button
-          type="button"
-          onClick={() => toggleForm("register")}
-          className="mt-2 text-[var(--aksen-amber)] underline text-sm hover:text-[var(--aksen-violet)]"
-        >
-          Need an account? Register
-        </button>
-      ) : (
-        <p className="mt-2 text-sm">
-          Have an account?{" "}
-          <button
-            type="button"
-            onClick={() => toggleForm("login")}
-            className="text-[var(--aksen-amber)] underline hover:text-[var(--aksen-violet)]"
-          >
-            Login
-          </button>
-        </p>
-      )}
+      <button
+        type="button"
+        onClick={() =>
+          toggleForm(currentForm === "login" ? "register" : "login")
+        }
+        className="mt-2 text-[var(--aksen-amber)] underline text-sm hover:text-[var(--aksen-violet)]"
+      >
+        {currentForm === "login"
+          ? "Need an account? Register"
+          : "Already have an account? Login"}
+      </button>
     </div>
   );
 }

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -2,12 +2,7 @@ import { useState } from "react";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { db, auth } from "../../firebase";
 import { doc, setDoc } from "firebase/firestore";
-import "../../styles/SettingsForm.css";
 
-/**
- * Form registrasi akun pengguna baru.
- * Menyimpan data dasar ke Firestore dan memberi tahu parent saat sukses.
- */
 function Register({ setIsLoggedIn }) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -15,20 +10,12 @@ function Register({ setIsLoggedIn }) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  // Tangani submit form registrasi
   const handleSubmit = async (e) => {
     e.preventDefault();
-
     if (password !== confirmPassword) {
       setErrorMessage("Password tidak cocok!");
       return;
     }
-
-    if (typeof setIsLoggedIn !== "function") {
-      setErrorMessage("Fungsi setIsLoggedIn belum tersedia.");
-      return;
-    }
-
     try {
       const userCredential = await createUserWithEmailAndPassword(
         auth,
@@ -44,19 +31,17 @@ function Register({ setIsLoggedIn }) {
         timeStudied: 0,
         timeOnBreak: 0,
       });
-      setIsLoggedIn(true);
+      setIsLoggedIn(true); // Successfully logged in
     } catch (error) {
-      console.error("Gagal registrasi:", error);
       setErrorMessage("Terjadi kesalahan: " + error.message);
     }
   };
 
   return (
-    <div className="Sf">
-      <h2 className="Sf__section-title">Register</h2>
+    <div className="pixel-card w-full max-w-md mx-auto p-6">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div className="Sf__group">
-          <label htmlFor="register-name" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="register-name" className="text-sm">
             Nama
           </label>
           <input
@@ -64,12 +49,12 @@ function Register({ setIsLoggedIn }) {
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
-        <div className="Sf__group">
-          <label htmlFor="register-email" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="register-email" className="text-sm">
             Email
           </label>
           <input
@@ -77,12 +62,12 @@ function Register({ setIsLoggedIn }) {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
-        <div className="Sf__group">
-          <label htmlFor="register-password" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="register-password" className="text-sm">
             Password
           </label>
           <input
@@ -90,12 +75,12 @@ function Register({ setIsLoggedIn }) {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
-        <div className="Sf__group">
-          <label htmlFor="register-confirm" className="Sf__label">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="register-confirm" className="text-sm">
             Confirm Password
           </label>
           <input
@@ -103,18 +88,22 @@ function Register({ setIsLoggedIn }) {
             type="password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="Sf__number"
+            className="pixel-frame bg-transparent px-3 py-2 text-[var(--foreground)] focus:border-[var(--aksen-amber)]"
             required
           />
         </div>
         <button
           type="submit"
-          className="Sf__btn Sf__btn--primary w-full mt-2"
+          className="pixel-btn pixel-btn--primary w-full mt-2"
         >
           Register
         </button>
       </form>
-      {errorMessage && <div className="Sf__error">{errorMessage}</div>}
+      {errorMessage && (
+        <div className="text-red-400 text-xs mt-3 text-center">
+          {errorMessage}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Reinstate pixel-styled login form and remove settings-form styling.
- Restore register form layout with pixel card and frame classes.
- Simplify auth form wrapper and add GitHub login button using pixel style.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a87212c2c08322b81507f3d5b9610c