### PR TITLE
style: remove borders from auth containers

### DIFF
--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -18,7 +18,7 @@ function Login({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="pixel-card w-full max-w-md mx-auto p-6">
+    <div className="w-full max-w-md mx-auto p-6 bg-[var(--glass)] backdrop-blur-[6px]">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <label htmlFor="login-email" className="text-sm">

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -38,7 +38,7 @@ function Register({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="pixel-card w-full max-w-md mx-auto p-6">
+    <div className="w-full max-w-md mx-auto p-6 bg-[var(--glass)] backdrop-blur-[6px]">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <label htmlFor="register-name" className="text-sm">


### PR DESCRIPTION
## Summary
- remove `pixel-card` border from login and register containers
- keep pixel frame borders on auth inputs for clarity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a8755aaeac8322ae7b29f20d727b6b