### PR TITLE
style: unify auth pages with settings design

### DIFF
--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -19,6 +19,7 @@ function Login({ setIsLoggedIn }) {
 
   return (
     <div className="w-full max-w-md mx-auto p-6 bg-[var(--glass)] backdrop-blur-[6px]">
+      <div className="Sf__section-title">Login</div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <label htmlFor="login-email" className="text-sm">
@@ -48,7 +49,7 @@ function Login({ setIsLoggedIn }) {
         </div>
         <button
           type="submit"
-          className="pixel-btn pixel-btn--primary w-full mt-2"
+          className="Sf__btn Sf__btn--primary w-full mt-2"
         >
           Login
         </button>

--- a/src/app/components/Timer/LoginRegisterForm.js
+++ b/src/app/components/Timer/LoginRegisterForm.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Login from "./Login";
 import Register from "./Register";
 import { redirectToGitHub } from "../../github";
+import "../../styles/SettingsForm.css";
 
 function LoginRegisterForm({ setIsLoggedIn }) {
   const [currentForm, setCurrentForm] = useState("login");
@@ -20,7 +21,7 @@ function LoginRegisterForm({ setIsLoggedIn }) {
       <button
         type="button"
         onClick={() => redirectToGitHub()}
-        className="pixel-btn pixel-btn--primary w-full"
+        className="Sf__btn Sf__btn--primary w-full"
       >
         Login with GitHub
       </button>

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -39,6 +39,7 @@ function Register({ setIsLoggedIn }) {
 
   return (
     <div className="w-full max-w-md mx-auto p-6 bg-[var(--glass)] backdrop-blur-[6px]">
+      <div className="Sf__section-title">Register</div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <label htmlFor="register-name" className="text-sm">
@@ -94,7 +95,7 @@ function Register({ setIsLoggedIn }) {
         </div>
         <button
           type="submit"
-          className="pixel-btn pixel-btn--primary w-full mt-2"
+          className="Sf__btn Sf__btn--primary w-full mt-2"
         >
           Register
         </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,8 +131,9 @@ textarea {
 /* ============================ */
 
 .pixel-frame {
-  border: 2px solid #fff;
-  box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
+  background: transparent;
+  border: 2px solid #000;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
 }
 
 .pixel-card {


### PR DESCRIPTION
## Summary
- match login & register input borders to settings style
- color auth buttons in accent violet and remove borders
- add Login/Register titles with consistent font

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68a87c5f73b8832286e68078d566725a