### PR TITLE
feat: add dedicated GitHub stats modal

### DIFF
--- a/src/app/components/Timer/GithubStats.js
+++ b/src/app/components/Timer/GithubStats.js
@@ -1,21 +1,16 @@
 "use client";
 
 /**
- * UserStatistics (Panel Statistik)
+ * GithubStats
  * ------------------------------------------------------------------
- * Menampilkan ringkasan menit fokus, menit istirahat, dan total menit.
- * - Mode tampilan: "total" (default) atau "hari ini"
- * - Menggunakan posisi statis tanpa drag.
- * - Sumber data berlapis:
- *   1) Props dari parent (jika ada) → prioritas tertinggi
- *   2) Firestore (jika login dan dokumen tersedia)
- *   3) localStorage (jika ada data)
+ * Menampilkan statistik GitHub dan riwayat aktivitas Push/PR.
+ * - Jika belum login GitHub, tampilkan tombol login.
+ * - Setelah login, tampilkan GitHub stats terlebih dahulu kemudian daftar
+ *   histori commit atau pull request.
  */
 
-import { useEffect, useMemo, useState } from "react";
 import "../../styles/GithubStats.css";
 import "../../styles/SettingsForm.css";
-import Modal from "./Modal";
 import { redirectToGitHub } from "../../github";
 
 export default function GithubStats({
@@ -23,87 +18,48 @@ export default function GithubStats({
   githubEvents = [],
   className = "",
 }) {
-  // ---------------- Muat data Firestore / localStorage (sekali saat mount & saat uid ganti) ----------------
-
   return (
-    <>
-      <section className={`Stat ${className || ""}`}>
-        <div className="flex items-center gap-2 mb-4">
-          <button
-            type="button"
-            className="Sf__btn Sf__btn--primary"
-            onClick={() => {
-              if (githubUser) {
-                setBukaGithub(true);
-              } else {
-                redirectToGitHub();
-              }
-            }}
-          >
-            {githubUser ? "GitHub" : "Login GitHub"}
-          </button>
-          <div className="Stat__section-title flex-1 text-center">
-            Github Stats
-          </div>
+    <section className={`Stat ${className || ""}`}>
+      <div className="Stat__section-title text-center">GitHub Stats</div>
+
+      {githubUser ? (
+        <div className="Stat__github">
+          <p className="text-center">
+            <img
+              src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true`}
+              width="48%"
+            />
+            <img
+              src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php`}
+              width="37.5%"
+            />
+          </p>
+
+          {githubEvents.length > 0 && (
+            <ul className="Stat__github-list">
+              {githubEvents.map((ev) => (
+                <li key={ev.id} className="Stat__github-item">
+                  <span className="repo">{ev.repo}</span>
+                  <span className="commit">{ev.commit?.slice(0, 7)}</span>
+                  <span className="changes">+{ev.additions}/-{ev.deletions}</span>
+                  <span className="time">
+                    {new Date(ev.time).toLocaleString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
-
-        {/* Pesan error (jika ada) */}
-        {pesanError && (
-          <div className="Stat__alert error" role="alert">
-            {pesanError}
-          </div>
-        )}
-      </section>
-
-      <Modal
-        buka={bukaGithub}
-        tutup={() => setBukaGithub(false)}
-        judul="GitHub Data"
-        lebar="lg"
-      >
-        {githubUser ? (
-          <div className="Stat__github">
-            {githubEvents.length > 0 && (
-              <ul className="Stat__github-list">
-                {githubEvents.map((ev) => (
-                  <li key={ev.id} className="Stat__github-item">
-                    <span className="repo">{ev.repo}</span>
-                    <span className="commit">{ev.commit?.slice(0, 7)}</span>
-                    <span className="changes">
-                      +{ev.additions}/-{ev.deletions}
-                    </span>
-                    <span className="time">
-                      {new Date(ev.time).toLocaleString()}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <p className="mt-4 text-center">
-              {githubUser && (
-                <>
-                  <img
-                    src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true`}
-                    width="48%"
-                  />
-                  <img
-                    src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php`}
-                    width="37.5%"
-                  />
-                </>
-              )}
-            </p>
-          </div>
-        ) : (
-          <button
-            type="button"
-            className="Sf__btn Sf__btn--primary w-full"
-            onClick={() => redirectToGitHub()}
-          >
-            Login with GitHub
-          </button>
-        )}
-      </Modal>
-    </>
+      ) : (
+        <button
+          type="button"
+          className="Sf__btn Sf__btn--primary w-full"
+          onClick={() => redirectToGitHub()}
+        >
+          Login with GitHub
+        </button>
+      )}
+    </section>
   );
 }
+

--- a/src/app/components/Timer/UserStatistics.js
+++ b/src/app/components/Timer/UserStatistics.js
@@ -14,9 +14,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import "../../styles/UserStatistics.css";
-import "../../styles/SettingsForm.css";
-import Modal from "./Modal";
-import { redirectToGitHub } from "../../github";
 
 import { db, auth } from "../../firebase";
 import { doc, getDoc } from "firebase/firestore";
@@ -43,8 +40,6 @@ export default function UserStatistics({
   totalTime,
   timeStudied,
   timeOnBreak,
-  githubUser,
-  githubEvents = [],
   className = "",
 }) {
   // ---------------- State UI ----------------
@@ -52,7 +47,6 @@ export default function UserStatistics({
   const [uidAktif, setUidAktif] = useState(userId || null);
   const [sedangMuat, setSedangMuat] = useState(false);
   const [pesanError, setPesanError] = useState("");
-  const [bukaGithub, setBukaGithub] = useState(false);
 
   // data bacaan (fallback-friendly)
   const [bacaTotal, setBacaTotal] = useState({
@@ -300,56 +294,6 @@ export default function UserStatistics({
           </div>
         )}
       </section>
-
-      <Modal
-        buka={bukaGithub}
-        tutup={() => setBukaGithub(false)}
-        judul="GitHub Data"
-        lebar="lg"
-      >
-        {githubUser ? (
-          <div className="Stat__github">
-            {githubEvents.length > 0 && (
-              <ul className="Stat__github-list">
-                {githubEvents.map((ev) => (
-                  <li key={ev.id} className="Stat__github-item">
-                    <span className="repo">{ev.repo}</span>
-                    <span className="commit">{ev.commit?.slice(0, 7)}</span>
-                    <span className="changes">
-                      +{ev.additions}/-{ev.deletions}
-                    </span>
-                    <span className="time">
-                      {new Date(ev.time).toLocaleString()}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <p className="mt-4 text-center">
-              {githubUser && (
-                <>
-                  <img
-                    src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true`}
-                    width="48%"
-                  />
-                  <img
-                    src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php`}
-                    width="37.5%"
-                  />
-                </>
-              )}
-            </p>
-          </div>
-        ) : (
-          <button
-            type="button"
-            className="Sf__btn Sf__btn--primary w-full"
-            onClick={() => redirectToGitHub()}
-          >
-            Login with GitHub
-          </button>
-        )}
-      </Modal>
     </>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -79,6 +79,7 @@ export default function Page() {
   const [sudahLogin, setSudahLogin] = useState(false);
   const [idPengguna, setIdPengguna] = useState(null);
   const [bukaStatistik, setBukaStatistik] = useState(false);
+  const [bukaGithubStats, setBukaGithubStats] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [githubUser, setGithubUser] = useState(null);
@@ -342,8 +343,8 @@ export default function Page() {
         {/* githubstats */}
         <button
           className="Db__ikonbtn"
-          onClick={() => setBukaStatistik((prev) => !prev)}
-          aria-label="GithubStats"
+          onClick={() => setBukaGithubStats((prev) => !prev)}
+          aria-label="github stats"
         >
           <Image
             src="/images/github.png"
@@ -441,8 +442,6 @@ export default function Page() {
           totalTime={statRingkas.totalTime}
           timeStudied={statRingkas.timeStudied}
           timeOnBreak={statRingkas.timeOnBreak}
-          githubUser={infoLogin.githubUser}
-          githubEvents={infoLogin.githubEvents}
         />
       </Modal>
 
@@ -494,7 +493,12 @@ export default function Page() {
         <LoginRegisterForm setIsLoggedIn={setIsLoggedIn} />
       </Modal>
 
-      <Modal>
+      {/* GitHub Stats Modal */}
+      <Modal
+        buka={bukaGithubStats}
+        tutup={() => setBukaGithubStats(false)}
+        lebar="lg"
+      >
         <GithubStats
           githubUser={infoLogin.githubUser}
           githubEvents={infoLogin.githubEvents}

--- a/src/app/styles/GithubStats.css
+++ b/src/app/styles/GithubStats.css
@@ -137,7 +137,7 @@
 .Stat__github-list {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 12px 0 0 0;
   display: grid;
   gap: 4px;
 }

--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -130,40 +130,6 @@
   color: #86efac;
 }
 
-/* GitHub activity ------------------------------------------------------- */
-.Stat__github {
-  margin-top: 12px;
-}
-.Stat__github-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 4px;
-}
-.Stat__github-item {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  gap: 4px;
-  background: rgba(17, 24, 39, 0.65);
-  border: 1px solid #ffffff;
-  padding: 4px;
-  font-size: 10px;
-  color: #e5e7eb;
-}
-.Stat__github-item .repo {
-  font-weight: bold;
-}
-.Stat__github-item .commit {
-  font-family: monospace;
-}
-.Stat__github-item .changes {
-  color: #86efac;
-}
-.Stat__github-item .time {
-  text-align: right;
-}
-
 /* Alert ------------------------------------------------------------------ */
 .Stat__alert {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- add separate GitHub Stats modal with its own state and trigger
- move GitHub login and history display into new GithubStats component
- clean UserStatistics and split GitHub-specific styles into dedicated CSS

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68a9392229748322ad8ea97fff785b0c