### PR TITLE
feat: improve github stats layout

### DIFF
--- a/src/app/components/Timer/GithubStats.js
+++ b/src/app/components/Timer/GithubStats.js
@@ -12,42 +12,77 @@
 import "../../styles/GithubStats.css";
 import "../../styles/SettingsForm.css";
 import { redirectToGitHub } from "../../github";
+import { useMemo, useState } from "react";
 
 export default function GithubStats({
   githubUser,
   githubEvents = [],
   className = "",
 }) {
+  const [periode, setPeriode] = useState("today");
+
+  const filteredEvents = useMemo(() => {
+    const now = new Date();
+    let start;
+    if (periode === "today") {
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    } else if (periode === "week") {
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
+    } else if (periode === "month") {
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+    } else {
+      start = new Date(0);
+    }
+    return githubEvents.filter((ev) => new Date(ev.time) >= start);
+  }, [githubEvents, periode]);
+
   return (
     <section className={`Stat ${className || ""}`}>
       <div className="Stat__section-title text-center">GitHub Stats</div>
 
       {githubUser ? (
         <div className="Stat__github">
-          <p className="text-center">
+          <div className="Stat__github-images">
             <img
+              className="Stat__github-image"
               src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true`}
-              width="48%"
+              alt="GitHub Stats"
             />
             <img
+              className="Stat__github-image"
               src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php`}
-              width="37.5%"
+              alt="Top Languages"
             />
-          </p>
+          </div>
 
           {githubEvents.length > 0 && (
-            <ul className="Stat__github-list">
-              {githubEvents.map((ev) => (
-                <li key={ev.id} className="Stat__github-item">
-                  <span className="repo">{ev.repo}</span>
-                  <span className="commit">{ev.commit?.slice(0, 7)}</span>
-                  <span className="changes">+{ev.additions}/-{ev.deletions}</span>
-                  <span className="time">
-                    {new Date(ev.time).toLocaleString()}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            <div className="Stat__history">
+              <div className="Stat__history-filter">
+                <select
+                  className="Stat__history-select"
+                  value={periode}
+                  onChange={(e) => setPeriode(e.target.value)}
+                >
+                  <option value="today">Hari ini</option>
+                  <option value="week">Minggu ini</option>
+                  <option value="month">Bulan ini</option>
+                </select>
+              </div>
+              {filteredEvents.length > 0 && (
+                <ul className="Stat__github-list">
+                  {filteredEvents.map((ev) => (
+                    <li key={ev.id} className="Stat__github-item">
+                      <span className="repo">{ev.repo}</span>
+                      <span className="commit">{ev.commit?.slice(0, 7)}</span>
+                      <span className="changes">+{ev.additions}/-{ev.deletions}</span>
+                      <span className="time">
+                        {new Date(ev.time).toLocaleString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           )}
         </div>
       ) : (

--- a/src/app/styles/GithubStats.css
+++ b/src/app/styles/GithubStats.css
@@ -134,6 +134,32 @@
 .Stat__github {
   margin-top: 12px;
 }
+.Stat__github-images {
+  display: flex;
+  width: 100%;
+}
+.Stat__github-image {
+  flex: 1;
+  border: 2px solid #fbbf24;
+  border-radius: 8px;
+  display: block;
+  width: 100%;
+}
+.Stat__history {
+  margin-top: 12px;
+}
+.Stat__history-filter {
+  text-align: center;
+  margin-bottom: 8px;
+}
+.Stat__history-select {
+  font-family: "Monocraft", monospace;
+  background: #1e1e2f;
+  color: #e5e7eb;
+  border: 2px solid #fbbf24;
+  border-radius: 4px;
+  padding: 4px 8px;
+}
 .Stat__github-list {
   list-style: none;
   padding: 0;
@@ -197,5 +223,8 @@
   }
   .Stat__grid {
     grid-template-columns: 1fr;
+  }
+  .Stat__github-images {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- align GitHub stats and top languages images side by side with matching width and borders
- add history filter to GitHub activity with today/week/month options
- style GitHub stats section for responsive layout

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompt for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a93f3d33708322bc96a539592cd68d