### PR TITLE
Refine GitHub stats layout and history filter

### DIFF
--- a/src/app/components/Timer/GithubStats.js
+++ b/src/app/components/Timer/GithubStats.js
@@ -44,46 +44,48 @@ export default function GithubStats({
         <div className="Stat__github">
           <div className="Stat__github-images">
             <img
-              className="Stat__github-image"
-              src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true`}
+              className="Stat__github-image Stat__github-image--stats"
+              src={`https://github-readme-stats.vercel.app/api?username=${githubUser.login}&show_icons=true&title_color=ffcc00&icon_color=00ffff&text_color=daf7dc&bg_color=1e1e2f&hide=issues&count_private=true&include_all_commits=true&hide_border=true`}
               alt="GitHub Stats"
             />
             <img
-              className="Stat__github-image"
-              src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php`}
+              className="Stat__github-image Stat__github-image--langs"
+              src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUser.login}&layout=compact&text_color=daf7dc&bg_color=1e1e2f&hide=php&hide_border=true`}
               alt="Top Languages"
             />
           </div>
 
-          {githubEvents.length > 0 && (
-            <div className="Stat__history">
-              <div className="Stat__history-filter">
-                <select
-                  className="Stat__history-select"
-                  value={periode}
-                  onChange={(e) => setPeriode(e.target.value)}
-                >
-                  <option value="today">Hari ini</option>
-                  <option value="week">Minggu ini</option>
-                  <option value="month">Bulan ini</option>
-                </select>
-              </div>
-              {filteredEvents.length > 0 && (
-                <ul className="Stat__github-list">
-                  {filteredEvents.map((ev) => (
-                    <li key={ev.id} className="Stat__github-item">
-                      <span className="repo">{ev.repo}</span>
-                      <span className="commit">{ev.commit?.slice(0, 7)}</span>
-                      <span className="changes">+{ev.additions}/-{ev.deletions}</span>
-                      <span className="time">
-                        {new Date(ev.time).toLocaleString()}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
+          <div className="Stat__history">
+            <div className="Stat__history-filter">
+              <select
+                className="Stat__history-select"
+                value={periode}
+                onChange={(e) => setPeriode(e.target.value)}
+              >
+                <option value="today">Hari ini</option>
+                <option value="week">Minggu ini</option>
+                <option value="month">Bulan ini</option>
+              </select>
             </div>
-          )}
+            {filteredEvents.length > 0 ? (
+              <ul className="Stat__github-list">
+                {filteredEvents.map((ev) => (
+                  <li key={ev.id} className="Stat__github-item">
+                    <span className="repo">{ev.repo}</span>
+                    <span className="commit">{ev.commit?.slice(0, 7)}</span>
+                    <span className="changes">+{ev.additions}/-{ev.deletions}</span>
+                    <span className="time">
+                      {new Date(ev.time).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="Stat__history-empty">
+                Belum ada push atau pull request
+              </div>
+            )}
+          </div>
         </div>
       ) : (
         <button

--- a/src/app/styles/GithubStats.css
+++ b/src/app/styles/GithubStats.css
@@ -134,39 +134,57 @@
 .Stat__github {
   margin-top: 12px;
 }
-.Stat__github-images {
-  display: flex;
-  width: 100%;
-}
-.Stat__github-image {
-  flex: 1;
-  border: 2px solid #fbbf24;
-  border-radius: 8px;
-  display: block;
-  width: 100%;
-}
-.Stat__history {
-  margin-top: 12px;
-}
-.Stat__history-filter {
-  text-align: center;
-  margin-bottom: 8px;
-}
-.Stat__history-select {
-  font-family: "Monocraft", monospace;
-  background: #1e1e2f;
-  color: #e5e7eb;
-  border: 2px solid #fbbf24;
-  border-radius: 4px;
-  padding: 4px 8px;
-}
-.Stat__github-list {
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 0 0;
-  display: grid;
-  gap: 4px;
-}
+  .Stat__github-images {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    gap: 0;
+  }
+  .Stat__github-image {
+    display: block;
+    border: none;
+    border-radius: 0;
+  }
+  .Stat__github-image--stats {
+    width: 48%;
+  }
+  .Stat__github-image--langs {
+    width: 37.5%;
+  }
+  .Stat__history {
+    margin-top: 12px;
+    text-align: center;
+  }
+  .Stat__history-filter {
+    margin: 0 auto 8px;
+    border: 1px solid #ffffff;
+    display: inline-block;
+    padding: 4px;
+  }
+  .Stat__history-select {
+    font-family: "Monocraft", monospace;
+    background: #1e1e2f;
+    color: #e5e7eb;
+    border: 1px solid #ffffff;
+    border-radius: 4px;
+    padding: 4px 8px;
+  }
+  .Stat__history-empty {
+    margin-top: 12px;
+    text-align: center;
+    color: #e5e7eb;
+    font-size: 12px;
+  }
+  .Stat__github-list {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0 0 0;
+    display: grid;
+    gap: 4px;
+    width: 100%;
+    text-align: left;
+  }
 .Stat__github-item {
   display: grid;
   grid-template-columns: 1fr auto auto auto;


### PR DESCRIPTION
## Summary
- stack GitHub stats and top languages images vertically without borders and set specific widths
- always show history filter with Hari ini/Minggu ini/Bulan ini options and no-data message
- style history filter with white border to match stats cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9425ff7ac83228156cf3387456a65