### PR TITLE
Limit width of GitHub history list

### DIFF
--- a/src/app/styles/GithubStats.css
+++ b/src/app/styles/GithubStats.css
@@ -179,10 +179,11 @@
   .Stat__github-list {
     list-style: none;
     padding: 0;
-    margin: 12px 0 0 0;
+    margin: 12px auto 0;
     display: grid;
     gap: 4px;
     width: 100%;
+    max-width: 450px;
     text-align: left;
   }
 .Stat__github-item {


### PR DESCRIPTION
## Summary
- center GitHub push/PR history list and cap its max width for a tidier layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a94a07bdb483228e604da82f1ee985