### PR TITLE
feat: enlarge and whiten github stats icon

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -351,7 +351,7 @@ export default function Page() {
             alt="ikon github"
             width={24}
             height={24}
-            className="Db__ikonimg"
+            className="Db__ikonimg Db__ikonimg--github"
             priority
           />
         </button>

--- a/src/app/styles/Dashboard.css
+++ b/src/app/styles/Dashboard.css
@@ -110,6 +110,12 @@
   height: 20px;
 }
 
+.Db__ikonimg--github {
+  width: 24px;
+  height: 24px;
+  filter: brightness(0) invert(1);
+}
+
 /* ---------------- Status login ---------------- */
 .Db__status {
   display: flex;


### PR DESCRIPTION
## Summary
- make GitHub stats button icon white and slightly larger to match other toolbar icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a94cc9d16883228ac0a3a66ae46a79