### PR TITLE
Ensure consistent modal dimensions

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -489,7 +489,7 @@ export default function Page() {
       </Modal>
 
       {/* Modal login/register */}
-      <Modal buka={loginOpen} tutup={() => setLoginOpen(false)}>
+      <Modal buka={loginOpen} tutup={() => setLoginOpen(false)} lebar="md">
         <LoginRegisterForm setIsLoggedIn={setIsLoggedIn} />
       </Modal>
 
@@ -497,7 +497,7 @@ export default function Page() {
       <Modal
         buka={bukaGithubStats}
         tutup={() => setBukaGithubStats(false)}
-        lebar="lg"
+        lebar="md"
       >
         <GithubStats
           githubUser={infoLogin.githubUser}

--- a/src/app/styles/Modal.css
+++ b/src/app/styles/Modal.css
@@ -21,8 +21,8 @@
 
 /* Konten modal (tema pixel) -------------------------------------------- */
 .Md__konten {
-  width: min(80vw, 500px); /* Lebar lebih kecil untuk lebih compact */
-  max-height: min(75vh, 700px); /* Menurunkan batas tinggi */
+  width: min(80vw, 500px); /* Lebar lebih kecil agar compact */
+  max-height: min(70vh, 600px); /* Tinggi lebih pendek dan responsif */
   overflow: auto;
   background: rgba(10, 10, 10, 0.75); /* Latar belakang lebih transparan */
   color: #e5e7eb;
@@ -36,15 +36,11 @@
   transition: transform 0.2s ease-out; /* Efek transisi */
 }
 
-/* Ukuran varian */
-.Md__konten--sm {
-  width: min(90vw, 400px); /* Lebar lebih kecil */
-}
-.Md__konten--md {
-  width: min(85vw, 550px); /* Lebar sedikit lebih besar */
-}
+/* Ukuran varian - dibuat seragam */
+.Md__konten--sm,
+.Md__konten--md,
 .Md__konten--lg {
-  width: min(90vw, 750px); /* Lebar lebih besar untuk ukuran besar */
+  width: min(80vw, 500px);
 }
 
 /* Header --------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- Shrink modal container to 80vw/500px width with 70vh max-height for a compact feel
- Apply medium-width modal across GitHub stats, user stats, settings and account dialogs for uniform sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a94fe5d9ac832294aef0834af050d0