### PR TITLE
Refine modal dimensions and unify content boxes

### DIFF
--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -18,7 +18,7 @@ function Login({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="w-full max-w-md mx-auto p-6 bg-transparent">
+    <div className="w-full h-full overflow-y-auto max-w-md mx-auto p-6 bg-transparent">
       <div className="Sf__section-title">Login</div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">

--- a/src/app/components/Timer/LoginRegisterForm.js
+++ b/src/app/components/Timer/LoginRegisterForm.js
@@ -11,7 +11,7 @@ function LoginRegisterForm({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex flex-col items-center gap-4 w-full h-full overflow-y-auto">
       {currentForm === "login" ? (
         <Login setIsLoggedIn={setIsLoggedIn} />
       ) : (

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -38,7 +38,7 @@ function Register({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="w-full max-w-md mx-auto p-6 bg-transparent">
+    <div className="w-full h-full overflow-y-auto max-w-md mx-auto p-6 bg-transparent">
       <div className="Sf__section-title">Register</div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">

--- a/src/app/styles/GithubStats.css
+++ b/src/app/styles/GithubStats.css
@@ -17,8 +17,9 @@
   font-family: "Monocraft", monospace;
   pointer-events: auto;
   overflow-y: auto;
-  max-height: 100%;
   width: 100%;
+  height: 100%;
+  max-height: 100%;
 }
 
 .Stat__section-title {

--- a/src/app/styles/Modal.css
+++ b/src/app/styles/Modal.css
@@ -21,8 +21,8 @@
 
 /* Konten modal (tema pixel) -------------------------------------------- */
 .Md__konten {
-  width: min(90vw, 750px); /* Samakan lebar untuk semua modal */
-  height: 80vh; /* Samakan tinggi dan jaga agar responsif */
+  width: min(85vw, 600px); /* Lebar modal sedikit lebih kecil */
+  height: 70vh; /* Tinggi modal lebih ringkas namun seragam */
   overflow: auto;
   background: rgba(10, 10, 10, 0.75); /* Latar belakang lebih transparan */
   color: #e5e7eb;
@@ -40,7 +40,8 @@
 .Md__konten--sm,
 .Md__konten--md,
 .Md__konten--lg {
-  width: min(90vw, 750px);
+  width: min(85vw, 600px);
+  height: 70vh; /* Samakan tinggi untuk semua varian */
 }
 
 /* Header --------------------------------------------------------------- */
@@ -105,6 +106,7 @@
 @media (max-width: 640px) {
   .Md__konten {
     padding: 12px;
-    width: min(90vw, 500px); /* Lebar modal lebih kecil untuk perangkat kecil */
+    width: min(90vw, 420px); /* Lebar modal lebih kecil untuk perangkat kecil */
+    height: 70vh; /* Pertahankan tinggi agar proporsional */
   }
 }

--- a/src/app/styles/SettingsForm.css
+++ b/src/app/styles/SettingsForm.css
@@ -1,6 +1,9 @@
 /* Wadah utama SettingsForm */
 .Sf {
   width: 100%;
+  height: 100%;
+  max-height: 100%;
+  overflow-y: auto; /* Pastikan isi tidak terpotong */
   font-family: var(--font-pixel);
   color: var(--foreground);
   margin: 0;

--- a/src/app/styles/UserStatistics.css
+++ b/src/app/styles/UserStatistics.css
@@ -17,8 +17,9 @@
   font-family: "Monocraft", monospace;
   pointer-events: auto;
   overflow-y: auto;
-  max-height: 100%;
   width: 100%;
+  height: 100%;
+  max-height: 100%;
 }
 
 .Stat__section-title {


### PR DESCRIPTION
## Summary
- Shrink modal container for a more compact GitHub Stats, User Statistics, Settings, and Account experience
- Ensure Stats, Settings, and Account panels fill the modal with uniform width/height and scrollable content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9549dfda0832285f75444ce2cbf2a