### PR TITLE
feat: auto break transition & music autoplay fix

### DIFF
--- a/src/app/components/Music/MusicPlayer.js
+++ b/src/app/components/Music/MusicPlayer.js
@@ -128,11 +128,21 @@ export default function MusicPlayer({ namaWallpaper = "", onGantiWallpaper }) {
 
     const onLoadedMetadata = () => {
       setDurasiDetik(el.duration || 0);
+      setWaktuSaatIni(0);
       // autoplay ketika user sebelumnya sudah menekan play
       if (sedangMain) {
-        el.play().catch(() => {
-          // autoplay mungkin diblokir — biarkan user tekan tombol play
-        });
+        el
+          .play()
+          .then(() => {
+            setSedangMain(true);
+          })
+          .catch(() => {
+            // autoplay mungkin diblokir — update status dan beri pesan
+            setSedangMain(false);
+            setPesanKesalahan(
+              "Tidak dapat mulai otomatis. Coba tekan tombol Play."
+            );
+          });
       }
     };
 
@@ -228,6 +238,7 @@ export default function MusicPlayer({ namaWallpaper = "", onGantiWallpaper }) {
   const handleBerikut = (dariError = false) => {
     mainkanSfxSingkat();
     setWaktuSaatIni(0);
+    setDurasiDetik(0);
 
     setIndeksLagu((idx) => {
       const nextIdx = acakAktif


### PR DESCRIPTION
## Summary
- auto-start break or long break when focus session ends
- resume focus automatically after breaks
- ensure music continues to next track and sync play/pause state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires Next.js ESLint plugin setup)*
- `NEXT_PUBLIC_FIREBASE_API_KEY=1 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=1 NEXT_PUBLIC_FIREBASE_PROJECT_ID=1 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=1 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1 NEXT_PUBLIC_FIREBASE_APP_ID=1 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=1 NEXT_PUBLIC_GITHUB_CLIENT_ID=1 NEXT_PUBLIC_GITHUB_REDIRECT_URI=1 GITHUB_CLIENT_SECRET=1 npm run build` *(aborted: build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68af9515beb48322bb952f303a6891a8