### PR TITLE
Refine timer page logic and strengthen error handling

### DIFF
--- a/src/app/components/Timer/GithubStats.js
+++ b/src/app/components/Timer/GithubStats.js
@@ -91,7 +91,13 @@ export default function GithubStats({
         <button
           type="button"
           className="Sf__btn Sf__btn--primary w-full"
-          onClick={() => redirectToGitHub()}
+          onClick={() => {
+            try {
+              redirectToGitHub();
+            } catch (error) {
+              console.error("GithubStats: gagal menginisiasi login GitHub:", error);
+            }
+          }}
         >
           Login with GitHub
         </button>

--- a/src/app/components/Timer/LocationWidget.js
+++ b/src/app/components/Timer/LocationWidget.js
@@ -21,6 +21,7 @@ export default function LocationWidget({ mode, className = "" }) {
   useEffect(() => {
     if (!navigator.geolocation) {
       setPermission("denied");
+      console.warn("LocationWidget: geolocation tidak tersedia pada browser ini.");
       return;
     }
     navigator.geolocation.getCurrentPosition(
@@ -31,8 +32,9 @@ export default function LocationWidget({ mode, className = "" }) {
           lon: pos.coords.longitude,
         });
       },
-      () => {
+      (error) => {
         setPermission("denied");
+        console.warn("LocationWidget: gagal mendapatkan izin lokasi:", error);
       }
     );
   }, []);
@@ -54,7 +56,11 @@ export default function LocationWidget({ mode, className = "" }) {
     )
       .then((r) => r.json())
       .then((d) => setWeather(d.current_weather))
-      .catch(() => {});
+      .catch((error) => {
+        if (error?.name === "AbortError") return;
+        console.error("LocationWidget: gagal memuat data cuaca:", error);
+        setWeather(null);
+      });
     return () => controller.abort();
   }, [permission, mode, coords]);
 

--- a/src/app/components/Timer/Login.js
+++ b/src/app/components/Timer/Login.js
@@ -14,6 +14,7 @@ function Login({ setIsLoggedIn }) {
       setIsLoggedIn(true); // User berhasil login
     } catch (error) {
       setErrorMessage("Gagal login: " + error.message);
+      console.error("Login: gagal login pengguna:", error);
     }
   };
 

--- a/src/app/components/Timer/Register.js
+++ b/src/app/components/Timer/Register.js
@@ -34,6 +34,7 @@ function Register({ setIsLoggedIn }) {
       setIsLoggedIn(true); // Successfully logged in
     } catch (error) {
       setErrorMessage("Terjadi kesalahan: " + error.message);
+      console.error("Register: gagal membuat akun baru:", error);
     }
   };
 

--- a/src/app/components/Timer/SettingsForm.js
+++ b/src/app/components/Timer/SettingsForm.js
@@ -238,7 +238,8 @@ export default function SettingsForm({
     try {
       setTimerPosition?.({ x: 0, y: 0 });
       setPesanSukses("Posisi Timer direset.");
-    } catch {
+    } catch (error) {
+      console.error("SettingsForm: gagal mereset posisi Timer:", error);
       setPesanError("Gagal mereset posisi Timer (fungsi tidak tersedia).");
     }
   };
@@ -247,7 +248,8 @@ export default function SettingsForm({
     try {
       setStatsPosition?.({ x: 0, y: 0 });
       setPesanSukses("Posisi Statistik direset.");
-    } catch {
+    } catch (error) {
+      console.error("SettingsForm: gagal mereset posisi Statistik:", error);
       setPesanError("Gagal mereset posisi Statistik (fungsi tidak tersedia).");
     }
   };
@@ -261,7 +263,9 @@ export default function SettingsForm({
         Math.max(Number(nilaiVolume || 0) / 100, 0),
         1
       );
-      refSfx.current.play().catch(() => {});
+      refSfx.current.play().catch((error) => {
+        console.warn("SettingsForm: browser menolak memutar bunyi percobaan:", error);
+      });
     } catch (e) {
       console.error(e);
       setPesanError("Tidak dapat memutar bunyi percobaan.");
@@ -366,9 +370,15 @@ export default function SettingsForm({
             onClick={async () => {
               try {
                 await signOut(auth);
-              } catch {}
-              logoutGitHub();
-              onLogoutGitHub?.();
+              } catch (error) {
+                console.error("SettingsForm: gagal logout Firebase:", error);
+              }
+              try {
+                logoutGitHub();
+                onLogoutGitHub?.();
+              } catch (error) {
+                console.error("SettingsForm: gagal logout GitHub:", error);
+              }
             }}
           >
             Log Out


### PR DESCRIPTION
## Summary
- refactor the home page to centralise safe localStorage helpers, improve GitHub token handling, and memoise callbacks for statistics and wallpaper changes
- streamline the timer component with a memoised duration helper, richer callback logging, and dependency-safe effects
- harden ancillary components (settings, location, auth, GitHub stats) with clearer error reporting and safer side effects

## Testing
- npm run lint *(fails: `next` binary missing in environment)*
- npx --yes next@15.3.4 lint *(fails: npm registry returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68caa3ce47e883228cfec60fef9f2f65